### PR TITLE
Add Simplified Chinese and Traditional Chinese translations

### DIFF
--- a/src/main/resources/assets/meteorplus/lang/zh_cn.json
+++ b/src/main/resources/assets/meteorplus/lang/zh_cn.json
@@ -1,0 +1,22 @@
+{
+	"gui.world_map.baritone_goal_here": "Baritone 目标标记",
+	"gui.world_map.baritone_path_here": "Baritone 路径标记",
+	"gui.world_map.baritone_elytra_here": "Baritone 鞘翅飞行标记",
+
+	"item.meteorplus.logo": "Meteor+ 主标识",
+	"item.meteorplus.logo_mods": "Meteor+ 整合包标识",
+
+	"modules.meteor-client.better-tooltips.beehive.honey-level": "§7蜂蜜等级：§e%d§7",
+	"modules.meteor-client.better-tooltips.beehive.bees": "§7蜜蜂数量：§e%d§7",
+
+	"modules.meteor-client.better-tooltips.kilobytes": "§7%s KB",
+	"modules.meteor-client.better-tooltips.bytes": "§7%s 字节",
+	"modules.meteor-client.better-tooltips.error-getting-bytes": "§c字节数据获取失败",
+
+	"modules.meteor-client.better-tooltips.unknown-inventory": "§4未知容器类型",
+
+	"modules.meteor-client.better-tooltips.hold-to-preview": "按住 §e%s§r 以预览",
+
+	"modules.meteor-client.inventory-tweaks.dump": "批量丢弃",
+	"modules.meteor-client.inventory-tweaks.steal": "快速拿取"
+}

--- a/src/main/resources/assets/meteorplus/lang/zh_tw.json
+++ b/src/main/resources/assets/meteorplus/lang/zh_tw.json
@@ -1,0 +1,22 @@
+{
+	"gui.world_map.baritone_goal_here": "Baritone 目標標記",
+	"gui.world_map.baritone_path_here": "Baritone 路徑標記",
+	"gui.world_map.baritone_elytra_here": "Baritone 鞘翅飛行標記",
+
+	"item.meteorplus.logo": "Meteor+ 主標誌",
+	"item.meteorplus.logo_mods": "Meteor+ 整合包標誌",
+
+	"modules.meteor-client.better-tooltips.beehive.honey-level": "§7蜂蜜等級：§e%d§7",
+	"modules.meteor-client.better-tooltips.beehive.bees": "§7蜜蜂數量：§e%d§7",
+
+	"modules.meteor-client.better-tooltips.kilobytes": "§7%s KB",
+	"modules.meteor-client.better-tooltips.bytes": "§7%s 位元組",
+	"modules.meteor-client.better-tooltips.error-getting-bytes": "§c位元組資料獲取失敗",
+
+	"modules.meteor-client.better-tooltips.unknown-inventory": "§4未知容器類型",
+
+	"modules.meteor-client.better-tooltips.hold-to-preview": "按住 §e%s§r 以預覽",
+
+	"modules.meteor-client.inventory-tweaks.dump": "批量丟棄",
+	"modules.meteor-client.inventory-tweaks.steal": "快速拿取"
+}


### PR DESCRIPTION
This PR adds localized language support for **Simplified Chinese (zh_cn)** and **Traditional Chinese (zh_tw)** to the Meteor+ client.